### PR TITLE
Add Supabase Auth with login, signup, and middleware

### DIFF
--- a/apps/course/.env.local.example
+++ b/apps/course/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/apps/course/middleware.ts
+++ b/apps/course/middleware.ts
@@ -1,0 +1,59 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { updateSession } from '@/lib/supabase/middleware'
+
+const PUBLIC_PATHS = ['/login', '/signup', '/callback']
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Skip middleware for static files, API routes, and Next.js internals
+  if (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/api') ||
+    pathname.includes('.') // static files
+  ) {
+    return NextResponse.next()
+  }
+
+  const { user, supabaseResponse } = await updateSession(request)
+  const isPublicPath = PUBLIC_PATHS.some((p) => pathname.startsWith(p))
+
+  // Authenticated users on auth pages -> redirect to dashboard
+  if (user && isPublicPath) {
+    return NextResponse.redirect(new URL('/dashboard', request.url))
+  }
+
+  // Unauthenticated users on protected pages -> redirect to login
+  if (!user && !isPublicPath && pathname !== '/') {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  // Purchase and onboarding gating (gracefully degrades without DB)
+  // Decision: skip purchase/onboarding checks if Prisma is unavailable
+  if (user && !isPublicPath && pathname !== '/' && pathname !== '/onboarding') {
+    try {
+      const { getPrismaUser } = await import('@/lib/auth/sync-user')
+      const prismaUser = user.email ? await getPrismaUser(user.email) : null
+
+      if (prismaUser) {
+        // No purchase -> redirect to marketing/purchase page
+        if (!prismaUser.purchasedAt) {
+          return NextResponse.redirect(new URL('/', request.url))
+        }
+
+        // Not onboarded -> redirect to onboarding
+        if (!prismaUser.onboardingComplete && pathname !== '/onboarding') {
+          return NextResponse.redirect(new URL('/onboarding', request.url))
+        }
+      }
+    } catch {
+      // Database unavailable — let authenticated users through
+    }
+  }
+
+  return supabaseResponse
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}

--- a/apps/course/package.json
+++ b/apps/course/package.json
@@ -13,6 +13,8 @@
     "@gyp/database": "workspace:*",
     "@gyp/shared": "workspace:*",
     "@gyp/ui": "workspace:*",
+    "@supabase/ssr": "^0.8.0",
+    "@supabase/supabase-js": "^2.98.0",
     "next": "^15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/course/src/app/(auth)/callback/page.tsx
+++ b/apps/course/src/app/(auth)/callback/page.tsx
@@ -1,7 +1,0 @@
-export default function AuthCallbackPage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <p className="text-text-muted">Processing authentication...</p>
-    </main>
-  );
-}

--- a/apps/course/src/app/(auth)/callback/route.ts
+++ b/apps/course/src/app/(auth)/callback/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { syncUser } from '@/lib/auth/sync-user'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/dashboard'
+
+  if (code) {
+    const supabase = await createClient()
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error && data.user) {
+      // Decision: Sync Supabase user to Prisma on every auth callback (ADR TBD)
+      const prismaUser = await syncUser(data.user)
+
+      // If new user without onboarding, redirect to onboarding
+      if (prismaUser && !prismaUser.onboardingComplete) {
+        return NextResponse.redirect(`${origin}/onboarding`)
+      }
+
+      return NextResponse.redirect(`${origin}${next}`)
+    }
+  }
+
+  // Auth code exchange failed — redirect to login with error
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+}

--- a/apps/course/src/app/(auth)/layout.tsx
+++ b/apps/course/src/app/(auth)/layout.tsx
@@ -1,0 +1,3 @@
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/course/src/app/(auth)/login/page.tsx
+++ b/apps/course/src/app/(auth)/login/page.tsx
@@ -1,10 +1,144 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/client'
+
 export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [magicLinkSent, setMagicLinkSent] = useState(false)
+
+  const supabase = createClient()
+
+  const handleSignIn = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    window.location.href = '/dashboard'
+  }
+
+  const handleMagicLink = async () => {
+    if (!email) {
+      setError('Enter your email address first.')
+      return
+    }
+    setError(null)
+    setLoading(true)
+
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/callback` },
+    })
+
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    setMagicLinkSent(true)
+    setLoading(false)
+  }
+
+  if (magicLinkSent) {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-md rounded-[12px] bg-surface p-8 shadow-card">
+          <h1 className="font-heading text-2xl text-primary">Check Your Email</h1>
+          <p className="mt-2 text-text-muted">
+            We sent a magic link to <strong>{email}</strong>. Click the link in the email to sign in.
+          </p>
+          <button
+            onClick={() => setMagicLinkSent(false)}
+            className="mt-4 text-sm text-primary hover:underline"
+          >
+            Back to login
+          </button>
+        </div>
+      </main>
+    )
+  }
+
   return (
     <main className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-md rounded-card bg-surface p-8 shadow-card">
+      <div className="w-full max-w-md rounded-[12px] bg-surface p-8 shadow-card">
         <h1 className="font-heading text-2xl text-primary">Log In</h1>
-        <p className="mt-2 text-text-muted">Auth placeholder</p>
+        <p className="mt-2 text-text-muted">Welcome back to Grow Your Practice.</p>
+
+        {error && (
+          <div className="mt-4 rounded-[6px] bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSignIn} className="mt-6 space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-text">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-[6px] border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-text">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-[6px] border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="Your password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-[8px] bg-primary px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
+          >
+            {loading ? 'Signing in...' : 'Sign In'}
+          </button>
+        </form>
+
+        <div className="mt-4 text-center">
+          <button
+            onClick={handleMagicLink}
+            disabled={loading}
+            className="text-sm text-primary hover:underline disabled:opacity-50"
+          >
+            Sign in with magic link instead
+          </button>
+        </div>
+
+        <div className="mt-6 text-center text-sm text-text-muted">
+          Don&apos;t have an account?{' '}
+          <Link href="/signup" className="text-primary hover:underline">
+            Sign up
+          </Link>
+        </div>
       </div>
     </main>
-  );
+  )
 }

--- a/apps/course/src/app/(auth)/signup/page.tsx
+++ b/apps/course/src/app/(auth)/signup/page.tsx
@@ -1,10 +1,138 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/client'
+
 export default function SignupPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+
+  const supabase = createClient()
+
+  const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.')
+      return
+    }
+
+    setLoading(true)
+
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: `${window.location.origin}/callback` },
+    })
+
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    setSuccess(true)
+    setLoading(false)
+  }
+
+  if (success) {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-md rounded-[12px] bg-surface p-8 shadow-card">
+          <h1 className="font-heading text-2xl text-primary">Check Your Email</h1>
+          <p className="mt-2 text-text-muted">
+            We sent a confirmation link to <strong>{email}</strong>. Click the link to activate your account.
+          </p>
+        </div>
+      </main>
+    )
+  }
+
   return (
     <main className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-md rounded-card bg-surface p-8 shadow-card">
-        <h1 className="font-heading text-2xl text-primary">Sign Up</h1>
-        <p className="mt-2 text-text-muted">Purchase flow placeholder</p>
+      <div className="w-full max-w-md rounded-[12px] bg-surface p-8 shadow-card">
+        <h1 className="font-heading text-2xl text-primary">Create Account</h1>
+        <p className="mt-2 text-text-muted">Start your AI journey with Grow Your Practice.</p>
+
+        {error && (
+          <div className="mt-4 rounded-[6px] bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSignUp} className="mt-6 space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-text">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-[6px] border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-text">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-[6px] border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="At least 8 characters"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-text">
+              Confirm Password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-[6px] border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="Confirm your password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-[8px] bg-primary px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
+          >
+            {loading ? 'Creating account...' : 'Create Account'}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center text-sm text-text-muted">
+          Already have an account?{' '}
+          <Link href="/login" className="text-primary hover:underline">
+            Log in
+          </Link>
+        </div>
       </div>
     </main>
-  );
+  )
 }

--- a/apps/course/src/app/(course)/layout.tsx
+++ b/apps/course/src/app/(course)/layout.tsx
@@ -1,3 +1,5 @@
+import { UserMenu } from './user-menu'
+
 export default function CourseLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen">
@@ -7,7 +9,12 @@ export default function CourseLayout({ children }: { children: React.ReactNode }
           <h2 className="font-heading text-lg text-primary">Grow Your Practice</h2>
         </div>
       </aside>
-      <main className="flex-1 p-6">{children}</main>
+      <div className="flex flex-1 flex-col">
+        <header className="flex items-center justify-end border-b border-border bg-surface px-6 py-3">
+          <UserMenu />
+        </header>
+        <main className="flex-1 p-6">{children}</main>
+      </div>
     </div>
-  );
+  )
 }

--- a/apps/course/src/app/(course)/user-menu.tsx
+++ b/apps/course/src/app/(course)/user-menu.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useAuth } from '@/lib/auth/use-auth'
+
+export function UserMenu() {
+  const { user, loading, signOut } = useAuth()
+
+  if (loading) {
+    return <div className="h-8 w-24 animate-pulse rounded-[6px] bg-border" />
+  }
+
+  if (!user) return null
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-text-muted">{user.email}</span>
+      <button
+        onClick={signOut}
+        className="rounded-[8px] border border-border px-3 py-1.5 text-sm text-text-muted hover:bg-background-dark hover:text-text"
+      >
+        Sign out
+      </button>
+    </div>
+  )
+}

--- a/apps/course/src/lib/auth/sync-user.ts
+++ b/apps/course/src/lib/auth/sync-user.ts
@@ -1,0 +1,54 @@
+import type { User as SupabaseUser } from '@supabase/supabase-js'
+
+/**
+ * Syncs a Supabase auth user to the Prisma User table.
+ * Creates a new record if one doesn't exist, returns the existing one if it does.
+ * Gracefully degrades if the database is unavailable.
+ */
+export async function syncUser(supabaseUser: SupabaseUser) {
+  try {
+    const { PrismaClient } = await import('@gyp/database')
+    const prisma = new PrismaClient()
+
+    try {
+      const email = supabaseUser.email
+      if (!email) return null
+
+      const existing = await prisma.user.findUnique({ where: { email } })
+      if (existing) return existing
+
+      const newUser = await prisma.user.create({
+        data: {
+          email,
+          name: supabaseUser.user_metadata?.full_name ?? null,
+          avatarUrl: supabaseUser.user_metadata?.avatar_url ?? null,
+        },
+      })
+      return newUser
+    } finally {
+      await prisma.$disconnect()
+    }
+  } catch (error) {
+    // Database unavailable — log and continue without sync
+    console.warn('[sync-user] Failed to sync user to database:', error)
+    return null
+  }
+}
+
+/**
+ * Fetches the Prisma user by email. Returns null if DB is unavailable.
+ */
+export async function getPrismaUser(email: string) {
+  try {
+    const { PrismaClient } = await import('@gyp/database')
+    const prisma = new PrismaClient()
+
+    try {
+      return await prisma.user.findUnique({ where: { email } })
+    } finally {
+      await prisma.$disconnect()
+    }
+  } catch {
+    return null
+  }
+}

--- a/apps/course/src/lib/auth/use-auth.ts
+++ b/apps/course/src/lib/auth/use-auth.ts
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { createClient } from '@/lib/supabase/client'
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const supabase = createClient()
+
+  useEffect(() => {
+    const getUser = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      setUser(user)
+      setLoading(false)
+    }
+
+    getUser()
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setUser(session?.user ?? null)
+        setLoading(false)
+      },
+    )
+
+    return () => subscription.unsubscribe()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const signOut = async () => {
+    await supabase.auth.signOut()
+    window.location.href = '/login'
+  }
+
+  return { user, loading, signOut }
+}

--- a/apps/course/src/lib/supabase/client.ts
+++ b/apps/course/src/lib/supabase/client.ts
@@ -1,0 +1,10 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  // During build/prerender, env vars may not be available. The browser client
+  // won't make real requests during SSR prerender, so placeholder values are safe.
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://placeholder.supabase.co'
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'placeholder'
+
+  return createBrowserClient(url, key)
+}

--- a/apps/course/src/lib/supabase/middleware.ts
+++ b/apps/course/src/lib/supabase/middleware.ts
@@ -1,0 +1,41 @@
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request })
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url || !key) {
+    // Supabase not configured — skip auth checks
+    return { user: null, supabaseResponse }
+  }
+
+  const supabase = createServerClient(
+    url,
+    key,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          )
+          supabaseResponse = NextResponse.next({ request })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          )
+        },
+      },
+    },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  return { user, supabaseResponse }
+}

--- a/apps/course/src/lib/supabase/server.ts
+++ b/apps/course/src/lib/supabase/server.ts
@@ -1,0 +1,38 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url || !key) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.',
+    )
+  }
+
+  return createServerClient(
+    url,
+    key,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            )
+          } catch {
+            // The `setAll` method is called from a Server Component where
+            // cookies cannot be set. This is safe to ignore if middleware
+            // is refreshing sessions.
+          }
+        },
+      },
+    },
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,10 +53,10 @@ importers:
         version: 10.4.27(postcss@8.5.6)
       eslint:
         specifier: ^9.18.0
-        version: 9.39.3(jiti@1.21.7)
+        version: 9.39.3(jiti@2.6.1)
       eslint-config-next:
         specifier: ^15.1.6
-        version: 15.5.12(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
+        version: 15.5.12(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       postcss:
         specifier: ^8.4.49
         version: 8.5.6
@@ -81,6 +81,12 @@ importers:
       '@gyp/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@supabase/ssr':
+        specifier: ^0.8.0
+        version: 0.8.0(@supabase/supabase-js@2.98.0)
+      '@supabase/supabase-js':
+        specifier: ^2.98.0
+        version: 2.98.0
       next:
         specifier: ^15.1.6
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -105,10 +111,10 @@ importers:
         version: 10.4.27(postcss@8.5.6)
       eslint:
         specifier: ^9.18.0
-        version: 9.39.3(jiti@2.6.1)
+        version: 9.39.3(jiti@1.21.7)
       eslint-config-next:
         specifier: ^15.1.6
-        version: 15.5.12(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 15.5.12(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
       postcss:
         specifier: ^8.4.49
         version: 8.5.6
@@ -1002,6 +1008,35 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.98.0':
+    resolution: {integrity: sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.98.0':
+    resolution: {integrity: sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.98.0':
+    resolution: {integrity: sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.98.0':
+    resolution: {integrity: sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.8.0':
+    resolution: {integrity: sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.76.1
+
+  '@supabase/storage-js@2.98.0':
+    resolution: {integrity: sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.98.0':
+    resolution: {integrity: sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1020,6 +1055,9 @@ packages:
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1027,6 +1065,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -1431,6 +1472,10 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1862,6 +1907,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2781,6 +2830,18 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3295,6 +3356,49 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.98.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.98.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.98.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.98.0':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.8.0(@supabase/supabase-js@2.98.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.98.0
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.98.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.98.0':
+    dependencies:
+      '@supabase/auth-js': 2.98.0
+      '@supabase/functions-js': 2.98.0
+      '@supabase/postgrest-js': 2.98.0
+      '@supabase/realtime-js': 2.98.0
+      '@supabase/storage-js': 2.98.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3314,6 +3418,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -3321,6 +3427,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.13
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -3804,6 +3914,8 @@ snapshots:
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4577,6 +4689,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 
@@ -5641,6 +5755,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.19.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Supabase client/server/middleware utilities using `@supabase/ssr`
- Login page with email/password + magic link, signup page with validation
- Auth callback route handler that syncs users to Prisma
- Middleware protecting course routes, redirecting based on auth/purchase/onboarding state
- `useAuth` hook and `UserMenu` component in course layout
- Graceful degradation when Supabase or database unavailable

## Test plan
- [x] `pnpm build` — all apps build clean
- [ ] Login/signup flows — requires Supabase project (Issue #29)
- [ ] Middleware redirects — requires running app with Supabase credentials

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)