### PR TITLE
Add Google SSO to auth pages

### DIFF
--- a/apps/course/src/app/(auth)/login/page.tsx
+++ b/apps/course/src/app/(auth)/login/page.tsx
@@ -82,6 +82,33 @@ export default function LoginPage() {
           </div>
         )}
 
+        <button
+          type="button"
+          onClick={async () => {
+            setError(null)
+            const { error } = await supabase.auth.signInWithOAuth({
+              provider: 'google',
+              options: { redirectTo: `${window.location.origin}/callback` },
+            })
+            if (error) setError(error.message)
+          }}
+          className="mt-6 flex w-full items-center justify-center gap-3 rounded-lg border border-[#E5E0D8] bg-white px-4 py-3 text-sm font-medium text-text hover:bg-[#F9FAFB]"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+            <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z" fill="#4285F4" />
+            <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z" fill="#34A853" />
+            <path d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332Z" fill="#FBBC05" />
+            <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.166 6.656 3.58 9 3.58Z" fill="#EA4335" />
+          </svg>
+          Continue with Google
+        </button>
+
+        <div className="mt-6 flex items-center gap-3">
+          <div className="h-px flex-1 bg-border" />
+          <span className="text-sm text-text-muted">or</span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+
         <form onSubmit={handleSignIn} className="mt-6 space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-text">

--- a/apps/course/src/app/(auth)/signup/page.tsx
+++ b/apps/course/src/app/(auth)/signup/page.tsx
@@ -71,6 +71,33 @@ export default function SignupPage() {
           </div>
         )}
 
+        <button
+          type="button"
+          onClick={async () => {
+            setError(null)
+            const { error } = await supabase.auth.signInWithOAuth({
+              provider: 'google',
+              options: { redirectTo: `${window.location.origin}/callback` },
+            })
+            if (error) setError(error.message)
+          }}
+          className="mt-6 flex w-full items-center justify-center gap-3 rounded-lg border border-[#E5E0D8] bg-white px-4 py-3 text-sm font-medium text-text hover:bg-[#F9FAFB]"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+            <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z" fill="#4285F4" />
+            <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z" fill="#34A853" />
+            <path d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332Z" fill="#FBBC05" />
+            <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.166 6.656 3.58 9 3.58Z" fill="#EA4335" />
+          </svg>
+          Continue with Google
+        </button>
+
+        <div className="mt-6 flex items-center gap-3">
+          <div className="h-px flex-1 bg-border" />
+          <span className="text-sm text-text-muted">or</span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+
         <form onSubmit={handleSignUp} className="mt-6 space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-text">


### PR DESCRIPTION
## Summary
- "Continue with Google" button with standard Google G icon on login and signup
- "or" divider between OAuth and email/password forms
- sync-user extracts name + avatar from Google profile metadata
- Updates existing users with Google data if name/avatar were missing

## Test plan
- [x] `pnpm build` — clean
- [ ] Google OAuth flow — requires Supabase Google provider config (Issue #29)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)