### PR TITLE
Fix oversized nav button on mobile

### DIFF
--- a/v/a/index.html
+++ b/v/a/index.html
@@ -207,6 +207,12 @@
     .hipaa-items { grid-template-columns: 1fr; }
     .newsletter-form { flex-direction: column; }
   }
+
+  @media (max-width: 600px) {
+    .nav-cta { font-size: 0.75rem; padding: 6px 14px; }
+    .nav-inner { padding: 0 12px; }
+    .wordmark-text { font-size: 0.95rem; }
+  }
 </style>
 <!-- Structured Data: Course -->
 <script type="application/ld+json">

--- a/v/b/index.html
+++ b/v/b/index.html
@@ -244,6 +244,12 @@
     .math-table { font-size: 0.85rem; }
     .math-table th, .math-table td { padding: 12px 14px; }
   }
+
+  @media (max-width: 600px) {
+    .nav-cta { font-size: 0.75rem; padding: 6px 14px; }
+    .nav-inner { padding: 0 12px; }
+    .wordmark-text { font-size: 0.95rem; }
+  }
 </style>
 <!-- Structured Data: Course -->
 <script type="application/ld+json">

--- a/v/c/index.html
+++ b/v/c/index.html
@@ -251,6 +251,12 @@
     .hipaa-items { grid-template-columns: 1fr; }
     .newsletter-form { flex-direction: column; }
   }
+
+  @media (max-width: 600px) {
+    .nav-cta { font-size: 0.75rem; padding: 6px 14px; }
+    .nav-inner { padding: 0 12px; }
+    .wordmark-text { font-size: 0.95rem; }
+  }
 </style>
 <!-- Structured Data: Course -->
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Adds responsive CSS for the header CTA button at `max-width: 600px`
- Reduces font size (0.9rem → 0.75rem), padding (10px 24px → 6px 14px), and nav padding on mobile
- Applied to all 3 A/B test variants

Closes #43

## Test plan
- [ ] View each variant on a mobile device or Chrome DevTools mobile view
- [ ] Verify the "Enroll Now" button is compact and doesn't crowd the wordmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)