### PR TITLE
Admin: Resource management + Users page

### DIFF
--- a/apps/admin/src/app/api/resources/[id]/route.ts
+++ b/apps/admin/src/app/api/resources/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const body = await request.json();
+  const { title, description, fileName, fileUrl, fileType, lessonId } = body;
+
+  const resource = await prisma.resource.update({
+    where: { id },
+    data: {
+      ...(title !== undefined && { title }),
+      ...(description !== undefined && { description }),
+      ...(fileName !== undefined && { fileName }),
+      ...(fileUrl !== undefined && { fileUrl }),
+      ...(fileType !== undefined && { fileType }),
+      ...(lessonId !== undefined && { lessonId }),
+    },
+  });
+
+  return NextResponse.json(resource);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  await prisma.resourceDownload.deleteMany({ where: { resourceId: id } });
+  await prisma.resource.delete({ where: { id } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/admin/src/app/api/resources/route.ts
+++ b/apps/admin/src/app/api/resources/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../lib/prisma';
+
+export async function GET(request: NextRequest) {
+  const moduleId = request.nextUrl.searchParams.get('moduleId');
+
+  const resources = await prisma.resource.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      lesson: {
+        select: {
+          id: true,
+          title: true,
+          order: true,
+          module: { select: { id: true, title: true, order: true } },
+        },
+      },
+    },
+    ...(moduleId && {
+      where: { lesson: { moduleId } },
+    }),
+  });
+
+  return NextResponse.json(resources);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { title, description, fileName, fileUrl, fileType, lessonId } = body;
+
+  if (!title || !fileName || !fileUrl || !fileType || !lessonId) {
+    return NextResponse.json(
+      { error: 'title, fileName, fileUrl, fileType, and lessonId are required' },
+      { status: 400 },
+    );
+  }
+
+  const resource = await prisma.resource.create({
+    data: {
+      title,
+      description: description || null,
+      fileName,
+      fileUrl,
+      fileType,
+      lessonId,
+    },
+  });
+
+  return NextResponse.json(resource, { status: 201 });
+}

--- a/apps/admin/src/app/api/users/[id]/route.ts
+++ b/apps/admin/src/app/api/users/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const user = await prisma.user.findUnique({
+    where: { id },
+    include: {
+      progress: {
+        include: {
+          lesson: {
+            select: {
+              id: true,
+              title: true,
+              order: true,
+              module: { select: { id: true, title: true, order: true } },
+            },
+          },
+        },
+        orderBy: { updatedAt: 'desc' },
+      },
+      moduleProgress: {
+        include: {
+          module: { select: { id: true, title: true, order: true } },
+        },
+        orderBy: { module: { order: 'asc' } },
+      },
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(user);
+}

--- a/apps/admin/src/app/api/users/route.ts
+++ b/apps/admin/src/app/api/users/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../lib/prisma';
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.searchParams.get('search') || '';
+  const page = parseInt(request.nextUrl.searchParams.get('page') || '1', 10);
+  const pageSize = 50;
+
+  const where = search
+    ? {
+        OR: [
+          { email: { contains: search, mode: 'insensitive' as const } },
+          { name: { contains: search, mode: 'insensitive' as const } },
+        ],
+      }
+    : {};
+
+  const [users, total, purchasedCount] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: {
+        _count: { select: { progress: true } },
+        progress: { where: { completed: true }, select: { id: true } },
+      },
+    }),
+    prisma.user.count({ where }),
+    prisma.user.count({ where: { purchasedAt: { not: null } } }),
+  ]);
+
+  const totalLessons = await prisma.lesson.count();
+
+  const usersWithProgress = users.map((u) => ({
+    id: u.id,
+    email: u.email,
+    name: u.name,
+    purchasedAt: u.purchasedAt,
+    onboardingComplete: u.onboardingComplete,
+    createdAt: u.createdAt,
+    completedLessons: u.progress.length,
+    totalLessons,
+    progressPercent: totalLessons > 0 ? Math.round((u.progress.length / totalLessons) * 100) : 0,
+  }));
+
+  return NextResponse.json({
+    users: usersWithProgress,
+    total,
+    purchasedCount,
+    totalLessons,
+    page,
+    pageSize,
+    totalPages: Math.ceil(total / pageSize),
+  });
+}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -32,6 +32,7 @@ const navSections = [
     heading: 'Content',
     links: [
       { href: '/modules', label: 'Modules' },
+      { href: '/resources', label: 'Resources' },
       { href: '/users', label: 'Users' },
     ],
   },

--- a/apps/admin/src/app/resources/page.tsx
+++ b/apps/admin/src/app/resources/page.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type ResourceLesson = {
+  id: string;
+  title: string;
+  order: number;
+  module: { id: string; title: string; order: number };
+};
+
+type Resource = {
+  id: string;
+  title: string;
+  description: string | null;
+  fileName: string;
+  fileUrl: string;
+  fileType: string;
+  lessonId: string;
+  createdAt: string;
+  lesson: ResourceLesson;
+};
+
+type Module = {
+  id: string;
+  title: string;
+  order: number;
+  lessons: { id: string; title: string; order: number }[];
+};
+
+type EditingResource = {
+  title: string;
+  description: string;
+  fileName: string;
+  fileUrl: string;
+  fileType: string;
+  lessonId: string;
+};
+
+const emptyForm: EditingResource = {
+  title: '',
+  description: '',
+  fileName: '',
+  fileUrl: '',
+  fileType: 'PDF',
+  lessonId: '',
+};
+
+export default function ResourcesPage() {
+  const [resources, setResources] = useState<Resource[]>([]);
+  const [modules, setModules] = useState<Module[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<string | 'new' | null>(null);
+  const [form, setForm] = useState<EditingResource>(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [filterModule, setFilterModule] = useState<string>('');
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    const url = filterModule
+      ? `/api/resources?moduleId=${filterModule}`
+      : '/api/resources';
+    const [resRes, modRes] = await Promise.all([
+      fetch(url),
+      fetch('/api/modules'),
+    ]);
+    setResources(await resRes.json());
+    const mods = await modRes.json();
+    // Modules endpoint includes lesson count but not lessons themselves
+    // Fetch each module's detail for the lesson dropdown
+    const modsWithLessons = await Promise.all(
+      mods.map(async (m: Module & { _count?: { lessons: number } }) => {
+        const r = await fetch(`/api/modules/${m.id}`);
+        const detail = await r.json();
+        return { id: m.id, title: m.title, order: m.order, lessons: detail.lessons || [] };
+      }),
+    );
+    setModules(modsWithLessons);
+    setLoading(false);
+  }, [filterModule]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  function startNew() {
+    setEditing('new');
+    setForm(emptyForm);
+  }
+
+  function startEdit(res: Resource) {
+    setEditing(res.id);
+    setForm({
+      title: res.title,
+      description: res.description || '',
+      fileName: res.fileName,
+      fileUrl: res.fileUrl,
+      fileType: res.fileType,
+      lessonId: res.lessonId,
+    });
+  }
+
+  function cancel() {
+    setEditing(null);
+    setForm(emptyForm);
+  }
+
+  async function save() {
+    setSaving(true);
+    const method = editing === 'new' ? 'POST' : 'PUT';
+    const url = editing === 'new' ? '/api/resources' : `/api/resources/${editing}`;
+
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+
+    setSaving(false);
+    setEditing(null);
+    setForm(emptyForm);
+    await fetchData();
+  }
+
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    await fetch(`/api/resources/${id}`, { method: 'DELETE' });
+    setDeleting(null);
+    await fetchData();
+  }
+
+  // Group lessons by module for the dropdown
+  const lessonOptions = modules
+    .sort((a, b) => a.order - b.order)
+    .flatMap((m) =>
+      (m.lessons || [])
+        .sort((a: { order: number }, b: { order: number }) => a.order - b.order)
+        .map((l: { id: string; title: string }) => ({
+          value: l.id,
+          label: `M${m.order}: ${m.title} → ${l.title}`,
+        })),
+    );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="font-heading text-2xl text-primary">Resources</h1>
+        <div className="flex items-center gap-3">
+          <select
+            className="rounded-input border border-border bg-background px-3 py-2 text-sm"
+            value={filterModule}
+            onChange={(e) => setFilterModule(e.target.value)}
+          >
+            <option value="">All modules</option>
+            {modules
+              .sort((a, b) => a.order - b.order)
+              .map((m) => (
+                <option key={m.id} value={m.id}>
+                  M{m.order}: {m.title}
+                </option>
+              ))}
+          </select>
+          <button
+            onClick={startNew}
+            className="rounded-button bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark"
+          >
+            + New Resource
+          </button>
+        </div>
+      </div>
+
+      {/* Edit/create form */}
+      {editing && (
+        <div className="mb-6 rounded-card border border-border bg-surface p-4">
+          <h2 className="mb-3 font-heading text-lg">
+            {editing === 'new' ? 'New Resource' : 'Edit Resource'}
+          </h2>
+          <div className="space-y-3">
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  Title
+                </label>
+                <input
+                  className="w-full rounded-input border border-border bg-background px-3 py-2 text-sm"
+                  value={form.title}
+                  onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+                />
+              </div>
+              <div className="w-24">
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  File Type
+                </label>
+                <select
+                  className="w-full rounded-input border border-border bg-background px-3 py-2 text-sm"
+                  value={form.fileType}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, fileType: e.target.value }))
+                  }
+                >
+                  <option>PDF</option>
+                  <option>DOCX</option>
+                  <option>XLSX</option>
+                  <option>PNG</option>
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-muted">
+                Description
+              </label>
+              <input
+                className="w-full rounded-input border border-border bg-background px-3 py-2 text-sm"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+              />
+            </div>
+
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  File Name
+                </label>
+                <input
+                  className="w-full rounded-input border border-border bg-background px-3 py-2 text-sm"
+                  placeholder="e.g. hipaa-decision-tree.pdf"
+                  value={form.fileName}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, fileName: e.target.value }))
+                  }
+                />
+              </div>
+              <div className="flex-1">
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  File URL
+                </label>
+                <input
+                  className="w-full rounded-input border border-border bg-background px-3 py-2 text-sm"
+                  placeholder="/resources/filename.pdf or Supabase URL"
+                  value={form.fileUrl}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, fileUrl: e.target.value }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-muted">
+                Linked Lesson
+              </label>
+              <select
+                className="w-full rounded-input border border-border bg-background px-3 py-2 text-sm"
+                value={form.lessonId}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, lessonId: e.target.value }))
+                }
+              >
+                <option value="">Select a lesson...</option>
+                {lessonOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <p className="text-xs text-text-muted">
+              File upload to Supabase Storage will be added once the bucket is configured.
+              For now, enter the file URL manually.
+            </p>
+
+            <div className="flex gap-2">
+              <button
+                onClick={save}
+                disabled={saving || !form.title || !form.fileName || !form.fileUrl || !form.lessonId}
+                className="rounded-button bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                onClick={cancel}
+                className="rounded-button border border-border px-4 py-2 text-sm hover:bg-background"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Resource list */}
+      {loading ? (
+        <p className="text-text-muted">Loading...</p>
+      ) : resources.length === 0 ? (
+        <p className="text-text-muted">No resources found.</p>
+      ) : (
+        <div className="space-y-2">
+          {resources.map((res) => (
+            <div
+              key={res.id}
+              className="flex items-center gap-3 rounded-card border border-border bg-surface p-3"
+            >
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{res.title}</span>
+                  <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600">
+                    {res.fileType}
+                  </span>
+                </div>
+                <p className="text-sm text-text-muted">
+                  M{res.lesson.module.order} L{res.lesson.order}: {res.lesson.title}
+                </p>
+                {res.description && (
+                  <p className="mt-0.5 text-xs text-text-muted line-clamp-1">
+                    {res.description}
+                  </p>
+                )}
+              </div>
+
+              <div className="text-right text-xs text-text-muted">
+                {res.fileName}
+              </div>
+
+              <div className="flex gap-1">
+                <button
+                  onClick={() => startEdit(res)}
+                  className="rounded-button border border-border px-3 py-1 text-xs hover:bg-background"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => {
+                    if (confirm(`Delete "${res.title}"?`)) handleDelete(res.id);
+                  }}
+                  disabled={deleting === res.id}
+                  className="rounded-button border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50"
+                >
+                  {deleting === res.id ? '...' : 'Delete'}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/app/users/page.tsx
+++ b/apps/admin/src/app/users/page.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type UserSummary = {
+  id: string;
+  email: string;
+  name: string | null;
+  purchasedAt: string | null;
+  onboardingComplete: boolean;
+  createdAt: string;
+  completedLessons: number;
+  totalLessons: number;
+  progressPercent: number;
+};
+
+type UserDetail = {
+  id: string;
+  email: string;
+  name: string | null;
+  purchasedAt: string | null;
+  onboardingComplete: boolean;
+  createdAt: string;
+  techComfortLevel: string | null;
+  progress: {
+    id: string;
+    completed: boolean;
+    videoWatchedPercent: number;
+    completedAt: string | null;
+    lesson: {
+      id: string;
+      title: string;
+      order: number;
+      module: { id: string; title: string; order: number };
+    };
+  }[];
+  moduleProgress: {
+    id: string;
+    completed: boolean;
+    completedAt: string | null;
+    module: { id: string; title: string; order: number };
+  }[];
+};
+
+type UsersResponse = {
+  users: UserSummary[];
+  total: number;
+  purchasedCount: number;
+  totalLessons: number;
+  page: number;
+  totalPages: number;
+};
+
+export default function UsersPage() {
+  const [data, setData] = useState<UsersResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [selectedUser, setSelectedUser] = useState<UserDetail | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(page) });
+    if (search) params.set('search', search);
+    const res = await fetch(`/api/users?${params}`);
+    setData(await res.json());
+    setLoading(false);
+  }, [page, search]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  async function viewUser(id: string) {
+    setLoadingDetail(true);
+    const res = await fetch(`/api/users/${id}`);
+    setSelectedUser(await res.json());
+    setLoadingDetail(false);
+  }
+
+  // Group progress by module for detail view
+  const progressByModule = selectedUser
+    ? selectedUser.progress.reduce(
+        (acc, p) => {
+          const key = p.lesson.module.id;
+          if (!acc[key]) {
+            acc[key] = {
+              module: p.lesson.module,
+              lessons: [],
+            };
+          }
+          acc[key].lessons.push(p);
+          return acc;
+        },
+        {} as Record<string, { module: { id: string; title: string; order: number }; lessons: typeof selectedUser.progress }>,
+      )
+    : {};
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="font-heading text-2xl text-primary">Users</h1>
+        <input
+          className="w-64 rounded-input border border-border bg-background px-3 py-2 text-sm"
+          placeholder="Search by name or email..."
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+        />
+      </div>
+
+      {/* Summary stats */}
+      {data && (
+        <div className="mb-6 grid grid-cols-4 gap-4">
+          <StatCard label="Total Users" value={data.total} />
+          <StatCard label="Purchased" value={data.purchasedCount} />
+          <StatCard
+            label="Conversion"
+            value={
+              data.total > 0
+                ? `${Math.round((data.purchasedCount / data.total) * 100)}%`
+                : '0%'
+            }
+          />
+          <StatCard label="Total Lessons" value={data.totalLessons} />
+        </div>
+      )}
+
+      {/* User detail panel */}
+      {selectedUser && (
+        <div className="mb-6 rounded-card border border-border bg-surface p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <div>
+              <h2 className="font-heading text-lg">
+                {selectedUser.name || selectedUser.email}
+              </h2>
+              <p className="text-sm text-text-muted">{selectedUser.email}</p>
+            </div>
+            <button
+              onClick={() => setSelectedUser(null)}
+              className="text-sm text-text-muted hover:text-text"
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="mb-4 flex gap-4 text-sm">
+            <span>
+              Purchased:{' '}
+              {selectedUser.purchasedAt
+                ? new Date(selectedUser.purchasedAt).toLocaleDateString()
+                : 'No'}
+            </span>
+            <span>
+              Onboarding: {selectedUser.onboardingComplete ? 'Complete' : 'Incomplete'}
+            </span>
+            {selectedUser.techComfortLevel && (
+              <span>Tech comfort: {selectedUser.techComfortLevel}</span>
+            )}
+          </div>
+
+          {/* Module progress */}
+          <h3 className="mb-2 text-sm font-medium">Module Progress</h3>
+          {selectedUser.moduleProgress.length === 0 ? (
+            <p className="text-sm text-text-muted">No progress yet.</p>
+          ) : (
+            <div className="mb-4 space-y-1">
+              {selectedUser.moduleProgress
+                .sort((a, b) => a.module.order - b.module.order)
+                .map((mp) => (
+                  <div
+                    key={mp.id}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <span
+                      className={`inline-block h-2 w-2 rounded-full ${mp.completed ? 'bg-green-500' : 'bg-gray-300'}`}
+                    />
+                    <span>
+                      M{mp.module.order}: {mp.module.title}
+                    </span>
+                    {mp.completedAt && (
+                      <span className="text-xs text-text-muted">
+                        {new Date(mp.completedAt).toLocaleDateString()}
+                      </span>
+                    )}
+                  </div>
+                ))}
+            </div>
+          )}
+
+          {/* Lesson progress by module */}
+          <h3 className="mb-2 text-sm font-medium">Lesson Progress</h3>
+          {Object.values(progressByModule).length === 0 ? (
+            <p className="text-sm text-text-muted">No lesson progress yet.</p>
+          ) : (
+            <div className="space-y-3">
+              {Object.values(progressByModule)
+                .sort((a, b) => a.module.order - b.module.order)
+                .map((group) => (
+                  <div key={group.module.id}>
+                    <p className="text-xs font-medium text-text-muted">
+                      M{group.module.order}: {group.module.title}
+                    </p>
+                    <div className="mt-1 space-y-0.5">
+                      {group.lessons
+                        .sort((a, b) => a.lesson.order - b.lesson.order)
+                        .map((lp) => (
+                          <div
+                            key={lp.id}
+                            className="flex items-center gap-2 text-sm"
+                          >
+                            <span
+                              className={`inline-block h-2 w-2 rounded-full ${lp.completed ? 'bg-green-500' : 'bg-amber-400'}`}
+                            />
+                            <span>
+                              L{lp.lesson.order}: {lp.lesson.title}
+                            </span>
+                            {lp.videoWatchedPercent > 0 && (
+                              <span className="text-xs text-text-muted">
+                                {Math.round(lp.videoWatchedPercent)}% watched
+                              </span>
+                            )}
+                          </div>
+                        ))}
+                    </div>
+                  </div>
+                ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* User table */}
+      {loading ? (
+        <p className="text-text-muted">Loading...</p>
+      ) : !data || data.users.length === 0 ? (
+        <p className="text-text-muted">No users found.</p>
+      ) : (
+        <>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs text-text-muted">
+                <th className="pb-2 font-medium">Name</th>
+                <th className="pb-2 font-medium">Email</th>
+                <th className="pb-2 font-medium">Purchased</th>
+                <th className="pb-2 font-medium">Progress</th>
+                <th className="pb-2 font-medium">Joined</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.users.map((user) => (
+                <tr
+                  key={user.id}
+                  onClick={() => viewUser(user.id)}
+                  className="cursor-pointer border-b border-border hover:bg-background"
+                >
+                  <td className="py-2 font-medium">
+                    {user.name || '—'}
+                  </td>
+                  <td className="py-2 text-text-muted">{user.email}</td>
+                  <td className="py-2">
+                    {user.purchasedAt ? (
+                      <span className="text-green-600">
+                        {new Date(user.purchasedAt).toLocaleDateString()}
+                      </span>
+                    ) : (
+                      <span className="text-text-muted">—</span>
+                    )}
+                  </td>
+                  <td className="py-2">
+                    <div className="flex items-center gap-2">
+                      <div className="h-1.5 w-16 rounded-full bg-gray-200">
+                        <div
+                          className="h-1.5 rounded-full bg-primary"
+                          style={{ width: `${user.progressPercent}%` }}
+                        />
+                      </div>
+                      <span className="text-xs text-text-muted">
+                        {user.progressPercent}%
+                      </span>
+                    </div>
+                  </td>
+                  <td className="py-2 text-text-muted">
+                    {new Date(user.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-center gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="rounded-button border border-border px-3 py-1 text-sm disabled:opacity-50"
+              >
+                ← Prev
+              </button>
+              <span className="text-sm text-text-muted">
+                Page {data.page} of {data.totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page === data.totalPages}
+                className="rounded-button border border-border px-3 py-1 text-sm disabled:opacity-50"
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {loadingDetail && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/10">
+          <p className="rounded-card bg-surface p-4 shadow text-text-muted">Loading user details...</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-card border border-border bg-surface p-4">
+      <p className="text-xs font-medium text-text-muted">{label}</p>
+      <p className="mt-1 text-2xl font-medium">{value}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Resources (closes #60):**
- Full CRUD API for resources with lesson linking
- `/resources` page with module filter, create/edit form with lesson dropdown
- File URL input for now — Supabase Storage upload deferred until bucket configured
- Added to sidebar nav

**Users (closes #61):**
- Paginated, searchable users API with progress calculation
- `/users` page with summary stats (total, purchased, conversion rate)
- User table with progress bars, click to expand per-module/per-lesson progress detail
- Pagination controls

Closes #60, closes #61

## Test plan

- [ ] `/resources` — lists all 19 seeded resources with correct module/lesson linkings
- [ ] Create/edit a resource — verify lesson dropdown shows all lessons grouped by module
- [ ] Filter resources by module
- [ ] Delete a resource
- [ ] `/users` — shows summary stats and empty table (no users in dev)
- [ ] Search filters work
- [ ] User detail panel shows module and lesson progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)