### PR TITLE
Admin: keyword tracker for SEO

### DIFF
--- a/apps/admin/src/app/api/keywords/[id]/route.ts
+++ b/apps/admin/src/app/api/keywords/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const body = await request.json();
+  const { keyword, monthlyVolume, cpc, intentMatch, notes, category } = body;
+
+  const updated = await prisma.keyword.update({
+    where: { id },
+    data: {
+      ...(keyword !== undefined && { keyword }),
+      ...(monthlyVolume !== undefined && { monthlyVolume }),
+      ...(cpc !== undefined && { cpc }),
+      ...(intentMatch !== undefined && { intentMatch }),
+      ...(notes !== undefined && { notes }),
+      ...(category !== undefined && { category }),
+    },
+  });
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  await prisma.keyword.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/admin/src/app/api/keywords/import/route.ts
+++ b/apps/admin/src/app/api/keywords/import/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/prisma';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { csv } = body;
+
+  if (!csv || typeof csv !== 'string') {
+    return NextResponse.json({ error: 'csv string is required' }, { status: 400 });
+  }
+
+  const lines = csv
+    .split('\n')
+    .map((line: string) => line.trim())
+    .filter((line: string) => line.length > 0);
+
+  const results = { created: 0, skipped: 0, errors: [] as string[] };
+
+  for (const line of lines) {
+    // Support tab or comma separated
+    const parts = line.includes('\t') ? line.split('\t') : line.split(',');
+    const keyword = parts[0]?.trim();
+    if (!keyword) continue;
+
+    // Skip header rows
+    if (keyword.toLowerCase() === 'keyword') continue;
+
+    const monthlyVolume = parts[1] ? parseInt(parts[1].trim().replace(/,/g, ''), 10) : null;
+    const cpc = parts[2] ? parseFloat(parts[2].trim().replace(/[$,]/g, '')) : null;
+
+    try {
+      await prisma.keyword.upsert({
+        where: { keyword },
+        create: {
+          keyword,
+          monthlyVolume: monthlyVolume && !isNaN(monthlyVolume) ? monthlyVolume : null,
+          cpc: cpc && !isNaN(cpc) ? cpc : null,
+        },
+        update: {
+          monthlyVolume: monthlyVolume && !isNaN(monthlyVolume) ? monthlyVolume : undefined,
+          cpc: cpc && !isNaN(cpc) ? cpc : undefined,
+        },
+      });
+      results.created++;
+    } catch (e) {
+      results.skipped++;
+      results.errors.push(`Failed: ${keyword}`);
+    }
+  }
+
+  return NextResponse.json(results, { status: 201 });
+}

--- a/apps/admin/src/app/api/keywords/route.ts
+++ b/apps/admin/src/app/api/keywords/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../lib/prisma';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const sort = searchParams.get('sort') || 'keyword';
+  const dir = (searchParams.get('dir') || 'asc') as 'asc' | 'desc';
+  const intentOnly = searchParams.get('intentOnly') === 'true';
+  const category = searchParams.get('category');
+
+  const where: Record<string, unknown> = {};
+  if (intentOnly) where.intentMatch = true;
+  if (category) where.category = category;
+
+  const keywords = await prisma.keyword.findMany({
+    where,
+    orderBy: { [sort]: dir },
+  });
+
+  return NextResponse.json(keywords);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { keyword, monthlyVolume, cpc, intentMatch, notes, category } = body;
+
+  if (!keyword) {
+    return NextResponse.json({ error: 'keyword is required' }, { status: 400 });
+  }
+
+  const created = await prisma.keyword.create({
+    data: {
+      keyword,
+      monthlyVolume: monthlyVolume ?? null,
+      cpc: cpc ?? null,
+      intentMatch: intentMatch ?? false,
+      notes: notes ?? null,
+      category: category ?? null,
+    },
+  });
+
+  return NextResponse.json(created, { status: 201 });
+}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -43,6 +43,7 @@ const navSections = [
       { href: '/marketing/ads', label: 'Ads' },
       { href: '/marketing/sales', label: 'Sales' },
       { href: '/marketing/funnel', label: 'Funnel' },
+      { href: '/marketing/keywords', label: 'Keywords' },
     ],
   },
 ];

--- a/apps/admin/src/app/marketing/keywords/page.tsx
+++ b/apps/admin/src/app/marketing/keywords/page.tsx
@@ -1,0 +1,449 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Keyword = {
+  id: string;
+  keyword: string;
+  monthlyVolume: number | null;
+  cpc: number | null;
+  intentMatch: boolean;
+  notes: string | null;
+  category: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SortKey = 'keyword' | 'monthlyVolume' | 'cpc' | 'intentMatch' | 'category';
+type SortDir = 'asc' | 'desc';
+
+export default function KeywordsPage() {
+  const [keywords, setKeywords] = useState<Keyword[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sort, setSort] = useState<SortKey>('keyword');
+  const [dir, setDir] = useState<SortDir>('asc');
+  const [intentOnly, setIntentOnly] = useState(false);
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [showImport, setShowImport] = useState(false);
+  const [csvText, setCsvText] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [editingCell, setEditingCell] = useState<{ id: string; field: string } | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [newKeyword, setNewKeyword] = useState('');
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const editRef = useRef<HTMLInputElement>(null);
+
+  const fetchKeywords = useCallback(async () => {
+    const params = new URLSearchParams({ sort, dir });
+    if (intentOnly) params.set('intentOnly', 'true');
+    if (categoryFilter) params.set('category', categoryFilter);
+    const res = await fetch(`/api/keywords?${params}`);
+    const data = await res.json();
+    setKeywords(data);
+    setLoading(false);
+  }, [sort, dir, intentOnly, categoryFilter]);
+
+  useEffect(() => {
+    fetchKeywords();
+  }, [fetchKeywords]);
+
+  useEffect(() => {
+    if (editingCell && editRef.current) {
+      editRef.current.focus();
+      editRef.current.select();
+    }
+  }, [editingCell]);
+
+  const handleSort = (key: SortKey) => {
+    if (sort === key) {
+      setDir(dir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSort(key);
+      setDir(key === 'keyword' ? 'asc' : 'desc');
+    }
+  };
+
+  const sortArrow = (key: SortKey) => {
+    if (sort !== key) return '';
+    return dir === 'asc' ? ' ↑' : ' ↓';
+  };
+
+  const handleSave = async (id: string, field: string, value: string) => {
+    let parsed: unknown = value;
+    if (field === 'monthlyVolume') parsed = value ? parseInt(value, 10) : null;
+    else if (field === 'cpc') parsed = value ? parseFloat(value) : null;
+    else if (field === 'notes' || field === 'category') parsed = value || null;
+
+    await fetch(`/api/keywords/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ [field]: parsed }),
+    });
+    setEditingCell(null);
+    fetchKeywords();
+  };
+
+  const handleToggleIntent = async (kw: Keyword) => {
+    await fetch(`/api/keywords/${kw.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ intentMatch: !kw.intentMatch }),
+    });
+    fetchKeywords();
+  };
+
+  const handleAdd = async () => {
+    if (!newKeyword.trim()) return;
+    await fetch('/api/keywords', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ keyword: newKeyword.trim() }),
+    });
+    setNewKeyword('');
+    fetchKeywords();
+  };
+
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/keywords/${id}`, { method: 'DELETE' });
+    setDeleteConfirm(null);
+    fetchKeywords();
+  };
+
+  const handleImport = async () => {
+    setImporting(true);
+    const res = await fetch('/api/keywords/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ csv: csvText }),
+    });
+    const result = await res.json();
+    alert(`Imported ${result.created} keywords. ${result.skipped} skipped.`);
+    setCsvText('');
+    setShowImport(false);
+    setImporting(false);
+    fetchKeywords();
+  };
+
+  // Compute categories for filter dropdown
+  const categories = Array.from(new Set(keywords.map((k) => k.category).filter(Boolean))) as string[];
+
+  // Summary stats (computed from full dataset — refetch without filters for accuracy)
+  const totalKeywords = keywords.length;
+  const flaggedCount = keywords.filter((k) => k.intentMatch).length;
+  const flaggedWithCpc = keywords.filter((k) => k.intentMatch && k.cpc != null);
+  const avgCpcFlagged =
+    flaggedWithCpc.length > 0
+      ? flaggedWithCpc.reduce((sum, k) => sum + (k.cpc ?? 0), 0) / flaggedWithCpc.length
+      : 0;
+
+  const startEdit = (id: string, field: string, currentValue: string) => {
+    setEditingCell({ id, field });
+    setEditValue(currentValue);
+  };
+
+  const cellClass =
+    'px-3 py-2 cursor-pointer hover:bg-primary/5 transition-colors';
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="font-heading text-2xl text-primary">Keywords</h1>
+        <button
+          onClick={() => setShowImport(!showImport)}
+          className="rounded-button bg-primary px-4 py-2 text-sm text-white hover:bg-primary/90"
+        >
+          {showImport ? 'Cancel Import' : 'Bulk Import'}
+        </button>
+      </div>
+
+      {/* Summary Stats */}
+      <div className="mb-4 flex gap-6 text-sm text-text-muted">
+        <span>
+          <strong className="text-text">{totalKeywords}</strong> keywords
+        </span>
+        <span>
+          <strong className="text-text">{flaggedCount}</strong> flagged for intent
+        </span>
+        <span>
+          Avg CPC (flagged): <strong className="text-text">${avgCpcFlagged.toFixed(2)}</strong>
+        </span>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex items-center gap-4 text-sm">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={intentOnly}
+            onChange={(e) => setIntentOnly(e.target.checked)}
+            className="accent-primary"
+          />
+          Intent match only
+        </label>
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="rounded-input border border-border bg-surface px-2 py-1"
+        >
+          <option value="">All categories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Bulk Import */}
+      {showImport && (
+        <div className="mb-4 rounded-card border border-border bg-surface p-4">
+          <p className="mb-2 text-sm text-text-muted">
+            Paste CSV from Google Keyword Planner (keyword, volume, CPC per line). Tab or
+            comma separated.
+          </p>
+          <textarea
+            value={csvText}
+            onChange={(e) => setCsvText(e.target.value)}
+            rows={8}
+            className="w-full rounded-input border border-border bg-background p-2 font-mono text-sm"
+            placeholder={`ai for therapists\t1200\t$2.50\ntherapist ai tools\t800\t$1.80`}
+          />
+          <button
+            onClick={handleImport}
+            disabled={importing || !csvText.trim()}
+            className="mt-2 rounded-button bg-accent px-4 py-2 text-sm text-white hover:bg-accent/90 disabled:opacity-50"
+          >
+            {importing ? 'Importing...' : 'Import'}
+          </button>
+        </div>
+      )}
+
+      {/* Add row */}
+      <div className="mb-2 flex gap-2">
+        <input
+          type="text"
+          value={newKeyword}
+          onChange={(e) => setNewKeyword(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+          placeholder="Add keyword..."
+          className="flex-1 rounded-input border border-border bg-surface px-3 py-2 text-sm"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!newKeyword.trim()}
+          className="rounded-button bg-primary px-4 py-2 text-sm text-white hover:bg-primary/90 disabled:opacity-50"
+        >
+          Add
+        </button>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <p className="text-sm text-text-muted">Loading...</p>
+      ) : (
+        <div className="overflow-x-auto rounded-card border border-border">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-border bg-surface text-xs uppercase text-text-muted">
+              <tr>
+                <th
+                  className="cursor-pointer px-3 py-2 hover:text-text"
+                  onClick={() => handleSort('keyword')}
+                >
+                  Keyword{sortArrow('keyword')}
+                </th>
+                <th
+                  className="cursor-pointer px-3 py-2 text-right hover:text-text"
+                  onClick={() => handleSort('monthlyVolume')}
+                >
+                  Volume{sortArrow('monthlyVolume')}
+                </th>
+                <th
+                  className="cursor-pointer px-3 py-2 text-right hover:text-text"
+                  onClick={() => handleSort('cpc')}
+                >
+                  CPC{sortArrow('cpc')}
+                </th>
+                <th
+                  className="cursor-pointer px-3 py-2 text-center hover:text-text"
+                  onClick={() => handleSort('intentMatch')}
+                >
+                  Intent{sortArrow('intentMatch')}
+                </th>
+                <th
+                  className="cursor-pointer px-3 py-2 hover:text-text"
+                  onClick={() => handleSort('category')}
+                >
+                  Category{sortArrow('category')}
+                </th>
+                <th className="px-3 py-2">Notes</th>
+                <th className="px-3 py-2 w-16"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keywords.map((kw) => (
+                <tr key={kw.id} className="border-b border-border last:border-0">
+                  {/* Keyword */}
+                  <td
+                    className={cellClass}
+                    onClick={() => startEdit(kw.id, 'keyword', kw.keyword)}
+                  >
+                    {editingCell?.id === kw.id && editingCell.field === 'keyword' ? (
+                      <input
+                        ref={editRef}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={() => handleSave(kw.id, 'keyword', editValue)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleSave(kw.id, 'keyword', editValue)
+                        }
+                        className="w-full rounded border border-primary bg-background px-1 py-0.5 text-sm"
+                      />
+                    ) : (
+                      kw.keyword
+                    )}
+                  </td>
+
+                  {/* Volume */}
+                  <td
+                    className={`${cellClass} text-right`}
+                    onClick={() =>
+                      startEdit(kw.id, 'monthlyVolume', kw.monthlyVolume?.toString() ?? '')
+                    }
+                  >
+                    {editingCell?.id === kw.id && editingCell.field === 'monthlyVolume' ? (
+                      <input
+                        ref={editRef}
+                        type="number"
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={() => handleSave(kw.id, 'monthlyVolume', editValue)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleSave(kw.id, 'monthlyVolume', editValue)
+                        }
+                        className="w-20 rounded border border-primary bg-background px-1 py-0.5 text-right text-sm"
+                      />
+                    ) : (
+                      kw.monthlyVolume?.toLocaleString() ?? '—'
+                    )}
+                  </td>
+
+                  {/* CPC */}
+                  <td
+                    className={`${cellClass} text-right`}
+                    onClick={() => startEdit(kw.id, 'cpc', kw.cpc?.toString() ?? '')}
+                  >
+                    {editingCell?.id === kw.id && editingCell.field === 'cpc' ? (
+                      <input
+                        ref={editRef}
+                        type="number"
+                        step="0.01"
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={() => handleSave(kw.id, 'cpc', editValue)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleSave(kw.id, 'cpc', editValue)
+                        }
+                        className="w-20 rounded border border-primary bg-background px-1 py-0.5 text-right text-sm"
+                      />
+                    ) : kw.cpc != null ? (
+                      `$${kw.cpc.toFixed(2)}`
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+
+                  {/* Intent */}
+                  <td className="px-3 py-2 text-center">
+                    <input
+                      type="checkbox"
+                      checked={kw.intentMatch}
+                      onChange={() => handleToggleIntent(kw)}
+                      className="accent-primary"
+                    />
+                  </td>
+
+                  {/* Category */}
+                  <td
+                    className={cellClass}
+                    onClick={() => startEdit(kw.id, 'category', kw.category ?? '')}
+                  >
+                    {editingCell?.id === kw.id && editingCell.field === 'category' ? (
+                      <input
+                        ref={editRef}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={() => handleSave(kw.id, 'category', editValue)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleSave(kw.id, 'category', editValue)
+                        }
+                        className="w-full rounded border border-primary bg-background px-1 py-0.5 text-sm"
+                      />
+                    ) : (
+                      kw.category ?? '—'
+                    )}
+                  </td>
+
+                  {/* Notes */}
+                  <td
+                    className={cellClass}
+                    onClick={() => startEdit(kw.id, 'notes', kw.notes ?? '')}
+                  >
+                    {editingCell?.id === kw.id && editingCell.field === 'notes' ? (
+                      <input
+                        ref={editRef}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={() => handleSave(kw.id, 'notes', editValue)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleSave(kw.id, 'notes', editValue)
+                        }
+                        className="w-full rounded border border-primary bg-background px-1 py-0.5 text-sm"
+                      />
+                    ) : (
+                      <span className="text-text-muted">{kw.notes || '—'}</span>
+                    )}
+                  </td>
+
+                  {/* Delete */}
+                  <td className="px-3 py-2 text-center">
+                    {deleteConfirm === kw.id ? (
+                      <div className="flex gap-1">
+                        <button
+                          onClick={() => handleDelete(kw.id)}
+                          className="text-xs text-red-600 hover:underline"
+                        >
+                          Yes
+                        </button>
+                        <button
+                          onClick={() => setDeleteConfirm(null)}
+                          className="text-xs text-text-muted hover:underline"
+                        >
+                          No
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setDeleteConfirm(kw.id)}
+                        className="text-text-muted hover:text-red-600"
+                        title="Delete"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {keywords.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-8 text-center text-text-muted">
+                    No keywords yet. Add one above or use Bulk Import.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -112,6 +112,18 @@ model ResourceDownload {
   resource Resource @relation(fields: [resourceId], references: [id])
 }
 
+model Keyword {
+  id            String   @id @default(cuid())
+  keyword       String   @unique
+  monthlyVolume Int?
+  cpc           Float?
+  intentMatch   Boolean  @default(false)
+  notes         String?
+  category      String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}
+
 model DailySnapshot {
   id   String   @id @default(uuid())
   date DateTime @unique // midnight UTC of the snapshot day


### PR DESCRIPTION
## Summary

- Keyword model in Prisma schema (volume, CPC, intent match, category, notes)
- API routes: list/create, update/delete, bulk CSV import
- Spreadsheet-style page at /marketing/keywords with inline editing, sorting, filtering
- Keywords nav link in Marketing section

## Test plan

- [ ] Navigate to /marketing/keywords — empty state shows
- [ ] Add a keyword, verify it appears
- [ ] Bulk import CSV (tab or comma separated)
- [ ] Sort by volume, CPC
- [ ] Filter by intent match, category
- [ ] Inline edit a cell, verify auto-save on blur
- [ ] Delete with confirmation

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)