### PR TITLE
Fix mark as complete + wire up progress tracking

### DIFF
--- a/apps/course/src/app/api/progress/lesson/route.ts
+++ b/apps/course/src/app/api/progress/lesson/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { PrismaClient } from '@gyp/database'
+
+const prisma = new PrismaClient()
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,45 +25,46 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'lessonId is required' }, { status: 400 })
     }
 
-    // TODO: When database is running, upsert LessonProgress via Prisma
-    // try {
-    //   const data: Record<string, unknown> = { userId: user.id, lessonId }
-    //   if (completed) data.completedAt = new Date()
-    //   if (videoWatchedPercent !== undefined) data.videoWatchedPercent = videoWatchedPercent
-    //
-    //   await prisma.lessonProgress.upsert({
-    //     where: { userId_lessonId: { userId: user.id, lessonId } },
-    //     create: data,
-    //     update: data,
-    //   })
-    //
-    //   // Auto-complete module if all lessons done
-    //   if (completed) {
-    //     const lesson = await prisma.lesson.findUnique({
-    //       where: { id: lessonId },
-    //       include: { module: { include: { lessons: true } } },
-    //     })
-    //     if (lesson) {
-    //       const allLessonIds = lesson.module.lessons.map(l => l.id)
-    //       const completedLessons = await prisma.lessonProgress.findMany({
-    //         where: { userId: user.id, lessonId: { in: allLessonIds }, completedAt: { not: null } },
-    //       })
-    //       if (completedLessons.length === allLessonIds.length) {
-    //         await prisma.moduleProgress.upsert({
-    //           where: { userId_moduleId: { userId: user.id, moduleId: lesson.moduleId } },
-    //           create: { userId: user.id, moduleId: lesson.moduleId, completedAt: new Date() },
-    //           update: { completedAt: new Date() },
-    //         })
-    //       }
-    //     }
-    //   }
-    // } catch (dbError) {
-    //   console.error('Database error:', dbError)
-    //   return NextResponse.json({ error: 'Failed to save progress' }, { status: 500 })
-    // }
+    try {
+      await prisma.lessonProgress.upsert({
+        where: { userId_lessonId: { userId: user.id, lessonId } },
+        create: {
+          userId: user.id,
+          lessonId,
+          completed: completed ?? false,
+          completedAt: completed ? new Date() : null,
+          videoWatchedPercent: videoWatchedPercent ?? 0,
+        },
+        update: {
+          ...(completed && { completed: true, completedAt: new Date() }),
+          ...(videoWatchedPercent !== undefined && { videoWatchedPercent }),
+        },
+      })
 
-    // Placeholder response until database is connected
-    console.log('Progress update:', { userId: user.id, lessonId, completed, videoWatchedPercent })
+      // Auto-complete module if all lessons done
+      if (completed) {
+        const lesson = await prisma.lesson.findUnique({
+          where: { id: lessonId },
+          include: { module: { include: { lessons: true } } },
+        })
+        if (lesson) {
+          const allLessonIds = lesson.module.lessons.map(l => l.id)
+          const completedCount = await prisma.lessonProgress.count({
+            where: { userId: user.id, lessonId: { in: allLessonIds }, completed: true },
+          })
+          if (completedCount === allLessonIds.length) {
+            await prisma.moduleProgress.upsert({
+              where: { userId_moduleId: { userId: user.id, moduleId: lesson.moduleId } },
+              create: { userId: user.id, moduleId: lesson.moduleId, completed: true, completedAt: new Date() },
+              update: { completed: true, completedAt: new Date() },
+            })
+          }
+        }
+      }
+    } catch (dbError) {
+      console.error('Database error:', dbError)
+      return NextResponse.json({ error: 'Failed to save progress' }, { status: 500 })
+    }
 
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/apps/course/src/components/lesson-actions.tsx
+++ b/apps/course/src/components/lesson-actions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { NextLessonInfo } from '@gyp/shared'
 import { ModuleCompleteToast } from './module-complete-toast'
@@ -59,6 +60,7 @@ export function LessonActions({
   isLastLessonInModule,
   moduleTitle,
 }: LessonActionsProps) {
+  const router = useRouter()
   const [completed, setCompleted] = useState(initialCompleted)
   const [loading, setLoading] = useState(false)
   const [justCompleted, setJustCompleted] = useState(false)
@@ -83,6 +85,9 @@ export function LessonActions({
         setEncouragement(
           ENCOURAGEMENTS[Math.floor(Math.random() * ENCOURAGEMENTS.length)] as string,
         )
+
+        // Refresh server components (sidebar, layout) to reflect new progress
+        router.refresh()
 
         // Check for module completion
         if (isLastLessonInModule) {


### PR DESCRIPTION
## Summary
- **Bug fix:** "Mark as Complete" was a no-op — API routes logged the request but never wrote to the database. Now upserts `LessonProgress` and auto-detects `ModuleProgress` via Prisma.
- **Progress bar:** Already existed on dashboard/module cards but always showed 0% because `getUserProgress()` returned empty arrays. Now reads real completion data from the database.
- Adds `router.refresh()` after completion so sidebar/layout update without a full page reload.

Closes #76

## Test plan
- [ ] Mark a lesson complete → verify it persists after page refresh
- [ ] Complete all lessons in a module → verify module shows as complete
- [ ] Check dashboard progress bar reflects real completion %
- [ ] Check sidebar updates checkmarks after marking complete
- [ ] Verify video watch % tracking still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)